### PR TITLE
Add support for different ROS distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,23 @@ By default, this variable only includes the `--symlink-install` option.
 **Note:** In the future, `cb` will allow adding extra arguments that will be passed to colcon, to avoid setting the environment variable.
 
 ### ROS 2 distro
-TODO.
+
+It is possible to select a different distro (rolling, humble, etc.) for each workspace. By default, when a workspace is added, the value stored in `$ROS_DISTRO` is used. It is also possible to select a ROS distribution when adding a new workspace as shown in the following example:
+
+```zsh
+rosws add foo humble
+```
+
+When a workspace is activated, the system will first load the environment for its corresponding ROS distro from `/opt/ros/<distro>/setup.zsh`, and then it will source the workspace environment.
+
+If you want to only load the distribution environment, you can do it by using the `rosws distro` command:
+
+```zsh
+rosws distro <distro>
+```
+
+This will source the environment in `/opt/ros/<distro>/setup.zsh`, also setting the `$ROS_DISTRO` variable.
+
 
 ## Automatic workspace switching
 **Note: This is still WIP and is not implemented.**

--- a/_cb
+++ b/_cb
@@ -13,20 +13,11 @@ function _cb() {
   local -a workspaces_list
 
   workspaces_list=( "${(f)mapfile[$ROSWS_CONFIG]//$HOME/~}" )
-
-  # TODO use load_workspaces
-  typeset -A rosws_workspaces
-  while read -r line
+  # Format output to be a bit prettier
+  for ((i = 1; i <= $#workspaces_list; i++))
   do
-    arr=(${(s,:,)line})
-    ws_name=${arr[1]}
-    ws_path=${arr[2]}
-
-    # replace ~ from path to fix completion (#17)
-    ws_path=${ws_path/#\~/$HOME}
-
-    rosws_workspaces[$ws_name]=$ws_path
-  done < $ROSWS_CONFIG
+    workspaces_list[$i]=$(sed 's/:/ --> /2' <<<"$workspaces_list[$i]")
+  done
 
   _arguments -C \
     '1: :->first_arg' && ret=0

--- a/_rosws
+++ b/_rosws
@@ -12,16 +12,28 @@ function _rosws() {
   local ret=1
 
   local -a commands
-  local -a workspaces_list
-
-  workspaces_list=( "${(f)mapfile[$ROSWS_CONFIG]//$HOME/~}" )
+  local -a workspaces_list=( "${(f)mapfile[$ROSWS_CONFIG]//$HOME/~}" )
+  local -a ros_distros=(
+    ardent
+    bouncy
+    crystal
+    dashing
+    eloquent
+    foxy
+    galactic
+    humble
+    iron
+    jazzy
+    rolling
+  )
 
   typeset -A rosws_workspaces
   while read -r line
   do
-    arr=(${(s,:,)line})
+    local arr=(${(s,:,)line})
     ws_name=${arr[1]}
-    ws_path=${arr[2]}
+    ws_distro=${arr[2]}
+    ws_path=${arr[3]}
 
     # replace ~ from path to fix completion (#17)
     ws_path=${ws_path/#\~/$HOME}
@@ -31,6 +43,7 @@ function _rosws() {
 
   commands=(
     'activate:Set the given workspace as the active one'
+    'distro:Set and source the given ROS 2 distro (humble, iron, rolling, etc.)'
     'add:Adds the current working directory to your registered workspaces'
     'rm:Removes the given workspace'
     'list:Print all registered workspaces'
@@ -64,6 +77,9 @@ function _rosws() {
           ;;
         activate)
           _describe -t rosws_workspaces "Workspaces" workspaces_list && ret=0
+          ;;
+        distro)
+          _describe -t ros_distros "ROS 2 Distros" ros_distros && ret=0
           ;;
         show)
           _describe -t rosws_workspaces "Workspaces" workspaces_list && ret=0

--- a/load_workspaces.zsh
+++ b/load_workspaces.zsh
@@ -21,12 +21,18 @@ function load_workspaces() {
     # load workspaces
     while read -r line
     do
+        # Config line example --> foo_ws:rolling:/path/to/foo_ws
         arr=(${(s,:,)line})
         ws_name=${arr[1]}
-        # join the rest, in case the path contains colons
-        ws_path=${(j,:,)arr[2,-1]}
-        rosws_workspaces[$ws_name]=$ws_path
+        # Save the distro and the path in an array
+        # join the rest of the path, in case it contains colons
+        ws_data=${(j,:,)arr[2,-1]}
+        # The value stored in ws_data contains the ROS distro and the path
+        # Example value after removing ws_name: --> rolling:/path/to/foo_ws
+        rosws_workspaces[$ws_name]=$ws_data
     done < "$ROSWS_CONFIG"
 
-    unset ws_path &> /dev/null # fixes issue #1 (from wd's original code)
+    unset ws_data &> /dev/null # fixes issue #1 (from wd's original code)
+    unset arr &> /dev/null
+    unset ws_name &> /dev/null
 }

--- a/rosws.zsh
+++ b/rosws.zsh
@@ -16,13 +16,6 @@ readonly ROSWS_YELLOW="\033[93m"
 readonly ROSWS_RED="\033[91m"
 readonly ROSWS_NOC="\033[m"
 
-# Temporarily set the ROS_DISTRO var to source the first setup
-# After this first source in /opt/..., this var will be properly set and exported
-# TODO: Find a proper way to configure this.
-#       Maybe add new subcommands to set distro and cb_extra_args.
-#       Those values can be persistent in a config file.
-# ROS_DISTRO=${ROS_DISTRO:-humble}
-
 ## functions
 
 # helpers
@@ -552,6 +545,7 @@ unset rosws_print_version
 unset rosws_o
 unset ws_distro
 unset ws_path
+unset parse_ws_data
 
 unset args
 

--- a/rosws.zsh
+++ b/rosws.zsh
@@ -138,7 +138,11 @@ parse_ws_data()
 # core
 activate_ws()
 {
-    parse_ws_data $ROSWS_ACTIVE_WS
+    local ws_name=$1
+    # Activate the workspace
+    export ROSWS_ACTIVE_WS=$ws_name
+
+    parse_ws_data $ws_name
     # Source ROS2 environment
     source /opt/ros/$ws_distro/setup.zsh
     # Source active workspace
@@ -152,20 +156,9 @@ rosws_activate()
 {
     local ws_name=$1
 
-    if [[ $ws_name =~ "^\.+$" ]]
+    if [[ ${rosws_workspaces[$ws_name]} != "" ]]
     then
-        if [[ $#1 < 2 ]]
-        then
-            rosws_exit_warn "Activate current directory?"
-        else
-            (( n = $#1 - 1 ))
-            cd -$n > /dev/null
-        fi
-    elif [[ ${rosws_workspaces[$ws_name]} != "" ]]
-    then
-        # Activate the workspace
-        export ROSWS_ACTIVE_WS=$ws_name
-        activate_ws
+        activate_ws $ws_name
     else
         rosws_exit_fail "Unknown workspace '${ws_name}'"
     fi
@@ -324,9 +317,9 @@ rosws_clean()
     do
         if [[ $line != "" ]]
         then
-            arr=(${(s,:,)line})
-            ws_name=${arr[1]}
-            ws_path=${arr[2]}
+            local arr=(${(s,:,)line})
+            local ws_name=${arr[1]}
+            local ws_path=${(j,:,)arr[3,-1]}
 
             if [ -d "${ws_path/#\~/$HOME}" ]
             then


### PR DESCRIPTION
This PR includes support to select a different ROS distro (rolling, humble, etc.) for each different workspace.

When activating a workspace, its corresponding environment is loaded first from `/opt/ros/<distro>/setup.zsh`.