### PR TITLE
Allow passing extra arguments to colcon build

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,16 +200,25 @@ rosws --version
 
 The configuration file where workspaces are registered is stored by default in `~/.config/ros2-env/workspaces`. It is possible to modify this by setting the environment variable `$ROSWS_CONFIG`.
 
-## Colcon parameters
+## Colcon arguments
 It is also possible to control the arguments passed to colcon when using the `cb` command, by setting the `$CB_EXTRA_ARGS` environment variable. For example:
 
 ```zsh
-export CB_EXTRA_ARGS="--symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release"
+export CB_EXTRA_ARGS="--symlink-install"
 ```
 
 By default, this variable only includes the `--symlink-install` option.
 
-**Note:** In the future, `cb` will allow adding extra arguments that will be passed to colcon, to avoid setting the environment variable.
+In addition, `cb` also allows passing extra arguments to colcon, that will be added after those in the environment variable. All the remainder arguments in the `cb` command will be forwarded. Example:
+
+```zsh
+# Pass custom cmake args (--symlink-install is already by included in $CB_EXTRA_ARGS)
+cb foo --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+# If the workspace is already active...
+cb --cmake-args -DCMAKE_BUILD_TYPE=Release
+```
+
 
 ## ROS 2 distro
 

--- a/_cb
+++ b/_cb
@@ -9,7 +9,6 @@ function _cb() {
   local ret=1
 
   local -a workspaces_list
-
   workspaces_list=( ${(f)"$(< $ROSWS_CONFIG)"} )
   # Format output to be a bit prettier
   for ((i = 1; i <= $#workspaces_list; i++))
@@ -17,13 +16,79 @@ function _cb() {
     workspaces_list[$i]=$(sed 's/:/ --> /2g' <<<"$workspaces_list[$i]")
   done
 
-  _arguments -C \
-    '1: :->first_arg' && ret=0
+  typeset -A rosws_workspaces
+  while read -r line
+  do
+    local arr=(${(s,:,)line})
+    ws_name=${arr[1]}
+    ws_distro=${arr[2]}
+    ws_path=${arr[-1]}
 
-  local target=$words[1]
+    # replace ~ from path to fix completion (#17)
+    ws_path=${ws_path/#\~/$HOME}
+
+    rosws_workspaces[$ws_name]=$ws_path
+  done < $ROSWS_CONFIG
+
+  _arguments -C \
+    '1: :->first_arg' \
+    '*: :->rem_args' \
+  && ret=0
+
+  local ws_name=$words[2]
+  local colcon_args
+  # Variable to store the length difference between "colcon build ..." and our "cb ..." command
+  # This will be needed to update the cursor position when calling colcon argcomplete
+  local cursor_point_diff
+  # If the first word is not a workspace name, change state to rem_args to process colcon args
+  if [[ ${words[2]} == --* ]]
+  then
+    state="rem_args"
+    ws_name=$ROSWS_ACTIVE_WS
+    colcon_args=(${words[@]:1})
+    cursor_point_diff=10  # "colcon build" - "cb" -> 10 characters
+  else
+    colcon_args=(${words[@]:2})
+    cursor_point_diff=$((12 - ${#words[2]} - 3))
+  fi
+
   if [[ $state == first_arg ]]
   then
+    # The first argument is the workspace to build
     _describe -t workspaces_list "Workspaces" workspaces_list && ret=0
+  else
+    # The remainder arguments will go to colcon
+    # Command to test colcon argcomplete in the terminal
+    # IFS=$'\013' COMP_LINE="colcon build --sym " COMP_POINT=${#COMP_LINE} _ARGCOMPLETE_SHELL="zsh" _ARGCOMPLETE_SUPPRESS_SPACE=1 _ARGCOMPLETE=1 colcon 8>&1 9>&2 1>&9 2>&1
+
+    # Create a fake line buffer so argcomplete thinks we are executing this command
+    local fake_buffer="colcon build ${colcon_args[@]}"
+    # In order to pass the correct cursor position, we need to determine
+    # the difference between "colcon build ..." and "cb $ws_name ..."
+    local fake_cursor_point=$((CURSOR + cursor_point_diff))
+
+    # cd into the directory when running colcon completion to find packages and etc.
+    local ws_path
+    if [[ -v rosws_workspaces[$ws_name] ]]; then
+      ws_path=$rosws_workspaces[$ws_name]
+    fi
+
+    # Normal mode: 8>&1 9>&2 1>/dev/null 2>&1
+    # Debug mode: 8>&1 9>&2 1>&9 2>&1
+    completions=($(cd $ws_path && \
+        IFS=$'\013' \
+        COMP_LINE="$fake_buffer" \
+        COMP_POINT="$fake_cursor_point" \
+        _ARGCOMPLETE_SHELL="zsh" \
+        _ARGCOMPLETE=1 \
+        _ARGCOMPLETE_SUPPRESS_SPACE=1 \
+        colcon 8>&1 9>&2 1>/dev/null 2>&1
+      )
+    )
+    # completions come in a single string. Split it by the 0x0b char (13 in decimal)
+    completions_list=(${(ps/\013/)completions})
+
+    _describe "Colcon arguments" completions_list -o nosort && ret=0
   fi
 
   return $ret

--- a/_rosws
+++ b/_rosws
@@ -11,8 +11,14 @@ function _rosws() {
   local ROSWS_CONFIG=${ROSWS_CONFIG:-$HOME/.config/ros2-env/workspaces}
   local ret=1
 
-  local -a commands
-  local -a workspaces_list=( "${(f)mapfile[$ROSWS_CONFIG]//$HOME/~}" )
+    local -a workspaces_list
+  workspaces_list=( ${(f)"$(< $ROSWS_CONFIG)"} )
+  # Format output to be a bit prettier
+  for ((i = 1; i <= $#workspaces_list; i++))
+  do
+    workspaces_list[$i]=$(sed 's/:/ --> /2g' <<<"$workspaces_list[$i]")
+  done
+
   local -a ros_distros=(
     ardent
     bouncy
@@ -41,7 +47,7 @@ function _rosws() {
     rosws_workspaces[$ws_name]=$ws_path
   done < $ROSWS_CONFIG
 
-  commands=(
+  local -a commands=(
     'activate:Set the given workspace as the active one'
     'distro:Set and source the given ROS 2 distro (humble, iron, rolling, etc.)'
     'add:Adds the current working directory to your registered workspaces'

--- a/cb.zsh
+++ b/cb.zsh
@@ -29,7 +29,6 @@ parse_ws_data()
     return 1
 }
 
-# TODO: Allow cb command to receive extra args and pass them to colcon.
 function _colcon_build_path()
 {
     if [ -z "$1" ]
@@ -40,7 +39,7 @@ function _colcon_build_path()
     p=$(pwd)
     cd "$1"
     shift
-    # colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+    # Add arguments defined in CB_EXTRA_ARGS and the ones passed to cb
     colcon build $CB_EXTRA_ARGS "$@"
     cd $p
 }

--- a/cb.zsh
+++ b/cb.zsh
@@ -39,8 +39,9 @@ function _colcon_build_path()
     fi
     p=$(pwd)
     cd "$1"
+    shift
     # colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
-    colcon build $CB_EXTRA_ARGS
+    colcon build $CB_EXTRA_ARGS "$@"
     cd $p
 }
 
@@ -53,7 +54,20 @@ source ${0:A:h}/load_workspaces.zsh
 load_workspaces
 
 # If no arguments, build the active workspace
-local ws_name=$1
+local ws_name
+local colcon_args=()
+
+# Separate workspace argument and colcon arguments
+# Check if the first argument is a colcon argument or workspace name
+if [[ "$1" == --* ]]; then
+    colcon_args=("$@")
+else
+    ws_name="$1"
+    shift
+    colcon_args=("$@")
+fi
+
+# If no arguments, build the active workspace
 if [ -z "$ws_name" ]
 then
     if [[ -v ROSWS_ACTIVE_WS ]]
@@ -73,7 +87,7 @@ then
                 source "${parent/#\~/$HOME}/install/local_setup.zsh"
             done
             # Build and source the final workspace
-            _colcon_build_path ${ws_path/#\~/$HOME}
+            _colcon_build_path ${ws_path/#\~/$HOME} "${colcon_args[@]}"
             source "${ws_path/#\~/$HOME}/install/local_setup.zsh"
         fi
     else
@@ -95,7 +109,7 @@ else
             source "${parent/#\~/$HOME}/install/local_setup.zsh"
         done
         # Build and source the final workspace
-        _colcon_build_path ${ws_path/#\~/$HOME}
+        _colcon_build_path ${ws_path/#\~/$HOME} "${colcon_args[@]}"
         source "${ws_path/#\~/$HOME}/install/local_setup.zsh"
         # Now this will be the active workspace
         export ROSWS_ACTIVE_WS=$ws_name


### PR DESCRIPTION
This PR solves #1.

The `_cb` completion script now invokes the `colcon` argcomplete and forwards the `colcon` arguments descriptions to `cb`.

The way to detect where the `cb` arguments stop and the `colcon build` arguments start is by detecting the first argument that starts with `"--"`. This works now because the only argument possible in `cb` is the workspace name, which should not start with `"--"`. If that changes in the future or we want to add `"--"` options to `cb`, we will need to find a different way to split `cb` and `colcon build` arguments.

Forwarding argument completions from `colcon` to `cb` was messy and there may be some issues, but I did not find any so far.