### PR TITLE
Feature: domain & rmw options

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,16 @@ rosws distro <distro>
 
 This will source the environment in `/opt/ros/<distro>/setup.zsh`, also setting the `$ROS_DISTRO` variable.
 
+## ROS DOMAIN ID
+
+You can select a different ROS_DOMAIN ID between 0 and 250. The default value is 0. Example:
+
+```zsh
+rosws domain <id>
+```
+
+This will set the `$ROS_DOMAIN_ID` variable.
+
 ## Chained workspaces
 When adding a new workspace, in addition to setting the base ROS 2 distro, it is also possible to set a list of parent workspaces (or underlay workspaces), that will be sourced before the overlay.
 

--- a/README.md
+++ b/README.md
@@ -241,13 +241,23 @@ This will source the environment in `/opt/ros/<distro>/setup.zsh`, also setting 
 
 ## ROS DOMAIN ID
 
-You can select a different ROS_DOMAIN ID between 0 and 250. The default value is 0. Example:
+You can select a different ROS_DOMAIN ID between 0 and 250 using `rosws domain` command. The default value is 0. Example:
 
 ```zsh
 rosws domain <id>
 ```
 
 This will set the `$ROS_DOMAIN_ID` variable.
+
+## RMW Implementation
+
+In ROS 2, there are several dds implementations you can use. These include `rmw_cyclonedds`, `rmw_zenoh`, and `rmw_fastrtps`, the latter being the default. To change the implementation to use, you have the command `rosws dds`. Example:
+
+```zsh
+rosws dds <rmw_implementation>
+```
+
+This will set the `$RMW_IMPLEMENTATION` variable.
 
 ## Chained workspaces
 When adding a new workspace, in addition to setting the base ROS 2 distro, it is also possible to set a list of parent workspaces (or underlay workspaces), that will be sourced before the overlay.

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This will set the `$ROS_DOMAIN_ID` variable.
 
 ## RMW Implementation
 
-In ROS 2, there are several dds implementations you can use. These include `rmw_cyclonedds`, `rmw_zenoh`, and `rmw_fastrtps`, the latter being the default. To change the implementation to use, you have the command `rosws dds`. Example:
+In ROS 2, there are several dds implementations you can use. Some of them are `rmw_fastrtps_cpp` (default), `rmw_cyclonedds_cpp`, `rmw_zenoh_cpp`, etc. To change the implementation to use, you have the `rosws dds` command, which will give you some dds options but you can put others. Example:
 
 ```zsh
 rosws dds <rmw_implementation>

--- a/README.md
+++ b/README.md
@@ -251,10 +251,10 @@ This will set the `$ROS_DOMAIN_ID` variable.
 
 ## RMW Implementation
 
-In ROS 2, there are several dds implementations you can use. Some of them are `rmw_fastrtps_cpp` (default), `rmw_cyclonedds_cpp`, `rmw_zenoh_cpp`, etc. To change the implementation to use, you have the `rosws dds` command, which will give you some dds options but you can put others. Example:
+In ROS 2, there are several rmw implementations you can use. Some of them are `rmw_fastrtps_cpp` (default), `rmw_cyclonedds_cpp`, `rmw_zenoh_cpp`, etc. To change the implementation to use, you have the `rosws rmw` command, which will give you some rmw options but you can put others. Example:
 
 ```zsh
-rosws dds <rmw_implementation>
+rosws rmw <rmw_implementation>
 ```
 
 This will set the `$RMW_IMPLEMENTATION` variable.

--- a/_rosws
+++ b/_rosws
@@ -50,6 +50,7 @@ function _rosws() {
   local -a commands=(
     'activate:Set the given workspace as the active one'
     'distro:Set and source the given ROS 2 distro (humble, iron, rolling, etc.)'
+    'domain:Set and source the given ROS DOMAIN ID'
     'add:Adds the current working directory to your registered workspaces'
     'rm:Removes the given workspace'
     'list:Print all registered workspaces'
@@ -88,6 +89,9 @@ function _rosws() {
           ;;
         distro)
           _describe -t ros_distros "ROS 2 Distros" ros_distros && ret=0
+          ;;
+        domain)
+          _message 'Write the ROS DOMAIN ID beetween 0 and 250' && ret=0
           ;;
         show)
           _describe -t rosws_workspaces "Workspaces" workspaces_list && ret=0

--- a/_rosws
+++ b/_rosws
@@ -33,7 +33,7 @@ function _rosws() {
     rolling
   )
 
-  local -a ros_dds_vendors=(
+  local -a ros_rmw_vendors=(
     rmw_fastrtps_cpp
     rmw_cyclonedds_cpp
     rmw_zenoh_cpp
@@ -57,7 +57,7 @@ function _rosws() {
     'activate:Set the given workspace as the active one'
     'distro:Set and source the given ROS 2 distro (humble, iron, rolling, etc.)'
     'domain:Set and source the given ROS DOMAIN ID'
-    'dds:Set and source the given ROS 2 DDS vendor (rmw_fastrtps_cpp, rmw_cyclonedds_cpp, rmw_zenoh_cpp, etc.)'
+    'rmw:Set and source the given ROS 2 RMW vendor (rmw_fastrtps_cpp, rmw_cyclonedds_cpp, rmw_zenoh_cpp, etc.)'
     'add:Adds the current working directory to your registered workspaces'
     'rm:Removes the given workspace'
     'list:Print all registered workspaces'
@@ -100,8 +100,8 @@ function _rosws() {
         domain)
           _message 'Write the ROS DOMAIN ID beetween 0 and 250' && ret=0
           ;;
-        dds)
-          _describe -t ros_dds_vendors "Suggested ROS 2 DDS Vendors" ros_dds_vendors && ret=0
+        rmw)
+          _describe -t ros_rmw_vendors "Suggested ROS 2 RMW Vendors" ros_rmw_vendors && ret=0
           ;;
         show)
           _describe -t rosws_workspaces "Workspaces" workspaces_list && ret=0

--- a/_rosws
+++ b/_rosws
@@ -33,6 +33,12 @@ function _rosws() {
     rolling
   )
 
+  local -a ros_dds_vendors=(
+    fastdds
+    cyclonedds
+    zenoh
+  )
+
   typeset -A rosws_workspaces
   while read -r line
   do
@@ -51,6 +57,7 @@ function _rosws() {
     'activate:Set the given workspace as the active one'
     'distro:Set and source the given ROS 2 distro (humble, iron, rolling, etc.)'
     'domain:Set and source the given ROS DOMAIN ID'
+    'dds:Set and source the given ROS 2 DDS vendor (fastdds, cyclonedds, zenoh'
     'add:Adds the current working directory to your registered workspaces'
     'rm:Removes the given workspace'
     'list:Print all registered workspaces'
@@ -92,6 +99,9 @@ function _rosws() {
           ;;
         domain)
           _message 'Write the ROS DOMAIN ID beetween 0 and 250' && ret=0
+          ;;
+        dds)
+          _describe -t ros_dds_vendors "ROS 2 DDS Vendors" ros_dds_vendors && ret=0
           ;;
         show)
           _describe -t rosws_workspaces "Workspaces" workspaces_list && ret=0

--- a/_rosws
+++ b/_rosws
@@ -34,9 +34,9 @@ function _rosws() {
   )
 
   local -a ros_dds_vendors=(
-    fastdds
-    cyclonedds
-    zenoh
+    rmw_fastrtps_cpp
+    rmw_cyclonedds_cpp
+    rmw_zenoh_cpp
   )
 
   typeset -A rosws_workspaces
@@ -57,7 +57,7 @@ function _rosws() {
     'activate:Set the given workspace as the active one'
     'distro:Set and source the given ROS 2 distro (humble, iron, rolling, etc.)'
     'domain:Set and source the given ROS DOMAIN ID'
-    'dds:Set and source the given ROS 2 DDS vendor (fastdds, cyclonedds, zenoh'
+    'dds:Set and source the given ROS 2 DDS vendor (rmw_fastrtps_cpp, rmw_cyclonedds_cpp, rmw_zenoh_cpp, etc.)'
     'add:Adds the current working directory to your registered workspaces'
     'rm:Removes the given workspace'
     'list:Print all registered workspaces'
@@ -101,7 +101,7 @@ function _rosws() {
           _message 'Write the ROS DOMAIN ID beetween 0 and 250' && ret=0
           ;;
         dds)
-          _describe -t ros_dds_vendors "ROS 2 DDS Vendors" ros_dds_vendors && ret=0
+          _describe -t ros_dds_vendors "Suggested ROS 2 DDS Vendors" ros_dds_vendors && ret=0
           ;;
         show)
           _describe -t rosws_workspaces "Workspaces" workspaces_list && ret=0

--- a/rosws.zsh
+++ b/rosws.zsh
@@ -177,12 +177,26 @@ rosws_domain()
     fi
 }
 
+rosws_dds()
+{
+    local dds=$1
+    if [[ $dds =~ ^(fastdds|cyclonedds|zenoh)$ ]]; then
+        case $dds in
+            fastdds)    export RMW_IMPLEMENTATION=rmw_fastrtps_cpp ;;
+            cyclonedds) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ;;
+            zenoh)   export RMW_IMPLEMENTATION=rmw_zenoh_cpp ;;
+        esac
+    else
+        rosws_exit_fail "Wrong ROS DDS vendor, must be one of: fastdds, cyclonedds, zenoh"
+    fi
+}
+
 rosws_add()
 {
     local ws_name=$1
     local distro=$2
     local ws_parents=(${@:3})
-    local cmdnames=(add activate distro rm show cd list path clean help)
+    local cmdnames=(add activate distro domain dds rm show cd list path clean help)
     local -a ros_distros=(
         ardent
         bouncy
@@ -518,6 +532,10 @@ else
                 ;;
             "--domain"|"domain")
                 rosws_domain "$2"
+                break
+                ;;
+            "--dds"|"dds")
+                rosws_dds "$2"
                 break
                 ;;
             "-r"|"--remove"|"rm")

--- a/rosws.zsh
+++ b/rosws.zsh
@@ -78,7 +78,7 @@ Commands:
     activate <workspace>      Set the given workspace as the active one
     distro <distro>           Set and source the given ROS 2 distro (humble, iron, rolling, etc.)
     domain <domain>           Set the ROS 2 domain ID (0-250)
-    dds <rmw_implementation>  Set the DDS implementation (rmw_fastrtps_cpp, rmw_cyclonedds_cpp, etc.)
+    rmw <rmw_implementation>  Set the RMW implementation (rmw_fastrtps_cpp, rmw_cyclonedds_cpp, etc.)
     add <workspace>           Adds the current working directory to your registered workspaces
     add                       Adds a new workspace with current directory's name
     add <workspace> <distro>  Adds a new workspace using a specific ROS distro
@@ -179,7 +179,7 @@ rosws_domain()
     fi
 }
 
-rosws_dds()
+rosws_rmw()
 {
     export RMW_IMPLEMENTATION=$1
 }
@@ -189,7 +189,7 @@ rosws_add()
     local ws_name=$1
     local distro=$2
     local ws_parents=(${@:3})
-    local cmdnames=(add activate distro domain dds rm show cd list path clean help)
+    local cmdnames=(add activate distro domain rmw rm show cd list path clean help)
     local -a ros_distros=(
         ardent
         bouncy
@@ -527,8 +527,8 @@ else
                 rosws_domain "$2"
                 break
                 ;;
-            "--dds"|"dds")
-                rosws_dds "$2"
+            "--rmw"|"rmw")
+                rosws_rmw "$2"
                 break
                 ;;
             "-r"|"--remove"|"rm")

--- a/rosws.zsh
+++ b/rosws.zsh
@@ -77,6 +77,8 @@ Commands:
     <workspace>               Set the given workspace as the active one
     activate <workspace>      Set the given workspace as the active one
     distro <distro>           Set and source the given ROS 2 distro (humble, iron, rolling, etc.)
+    domain <domain>           Set the ROS 2 domain ID (0-250)
+    dds <rmw_implementation>  Set the DDS implementation (rmw_fastrtps_cpp, rmw_cyclonedds_cpp, etc.)
     add <workspace>           Adds the current working directory to your registered workspaces
     add                       Adds a new workspace with current directory's name
     add <workspace> <distro>  Adds a new workspace using a specific ROS distro
@@ -179,16 +181,7 @@ rosws_domain()
 
 rosws_dds()
 {
-    local dds=$1
-    if [[ $dds =~ ^(fastdds|cyclonedds|zenoh)$ ]]; then
-        case $dds in
-            fastdds)    export RMW_IMPLEMENTATION=rmw_fastrtps_cpp ;;
-            cyclonedds) export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ;;
-            zenoh)   export RMW_IMPLEMENTATION=rmw_zenoh_cpp ;;
-        esac
-    else
-        rosws_exit_fail "Wrong ROS DDS vendor, must be one of: fastdds, cyclonedds, zenoh"
-    fi
+    export RMW_IMPLEMENTATION=$1
 }
 
 rosws_add()

--- a/rosws.zsh
+++ b/rosws.zsh
@@ -166,6 +166,17 @@ rosws_distro()
     source /opt/ros/$1/setup.zsh || rosws_exit_fail "ROS distro '${1}' is not installed"
 }
 
+rosws_domain()
+{
+    local domain=$1
+    if [[ $domain =~ ^([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|250)$ ]]
+    then
+        export ROS_DOMAIN_ID=$domain
+    else
+        rosws_exit_fail "ROS DOMAIN ID must be a number between 0 and 250"
+    fi
+}
+
 rosws_add()
 {
     local ws_name=$1
@@ -503,6 +514,10 @@ else
                 ;;
             "--distro"|"distro")
                 rosws_distro "$2"
+                break
+                ;;
+            "--domain"|"domain")
+                rosws_domain "$2"
                 break
                 ;;
             "-r"|"--remove"|"rm")


### PR DESCRIPTION
Hiiii

I've added two new options that I find quite useful when using your plugin, since they make changing the domain ID and rmw_implementation much easier (learning the export lines is difficult, jeje).

##

**ROS Domain ID**
```zsh
~$ rosws domain
Write the ROS DOMAIN ID beetween 0 and 250
~$ rosws domain 5
~$ echo $ROS_DOMAIN_ID 
5
~$ rosws domain 251   
 * ROS DOMAIN ID must be a number between 0 and 250
```

**RMW Implementation**
```zsh
~$ rosws dds
ROS 2 DDS Vendors
cyclonedds  fastdds     zenoh
~$ rosws dds cyclonedds 
~$ echo $RMW_IMPLEMENTATION 
rmw_cyclonedds_cpp
~$ rosws dds potatodds
 * Wrong ROS DDS vendor, must be one of: fastdds, cyclonedds, zenoh
 ```
##

Both have auto-completion and a brief description of what they do. I have also modified the README.md with a small explanation and example of use.

I hope you like the new options added and of course I am open to modifying any changes you suggest.

Regards ^^

